### PR TITLE
Enables support for upserting using relationship fields

### DIFF
--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -102,11 +102,31 @@ module SalesforceBulkApi
       data.keys.each do |k|
         if k.is_a?(Hash)
           xml += build_sobject(k)
+        elsif k.to_s.include? '.'
+          relations = k.to_s.split('.')
+          parent = relations[0]
+          child = relations[1..-1].join('.')
+          xml += "<#{parent}>#{build_sobject({ child => data[k] })}</#{parent}>"
         elsif data[k] != :type
           xml += "<#{k}>#{data[k]}</#{k}>"
         end
       end
       xml += '</sObject>'
+    end
+
+    def build_relationship_sobject(key, value)
+      if key.to_s.include? '.'
+        relations = key.to_s.split('.')
+        parent = relations[0]
+        child = relations[1..-1].join('.')
+        xml = "<#{parent}>"
+        xml += "<sObject>"
+        xml += build_relationship_sobject(child, value)
+        xml += "</sObject>"
+        xml += "</#{parent}>"
+      else
+        xml = "<#{key}>#{value}</#{key}>"
+      end
     end
 
     def create_sobject(keys, r)
@@ -116,6 +136,8 @@ module SalesforceBulkApi
           sobject_xml += "<#{k}>"
           sobject_xml += build_sobject(r[k])
           sobject_xml += "</#{k}>"
+        elsif k.to_s.include? '.'
+          sobject_xml += build_relationship_sobject(k, r[k])
         elsif !r[k].to_s.empty?
           sobject_xml += "<#{k}>"
           if r[k].respond_to?(:encode)


### PR DESCRIPTION
For example, we can now use keys of the form
`Contact__r.External_ID__c` to update the `Contact__c` field
using the `External_ID__c` field rather than the salesforce Id field.
